### PR TITLE
Disable the Chrome "autofill"

### DIFF
--- a/src/Suggestions.vue
+++ b/src/Suggestions.vue
@@ -6,6 +6,7 @@
            v-on:blur="hideItems"
            v-on:focus="showItems = true"
            v-model="query"
+           :autocomplete="Math.random()"
            :placeholder="extendedOptions.placeholder">
     <div class="suggestions">
       <ul class="items" v-show="items.length > 0 && showItems === true">


### PR DESCRIPTION
The chrome "autofill" functionality is not desirable on an autocomplete input.  It has to be disabled on such fields.
The best way to disable "autofill" is to set input autocomplete attribute to a random value.