### PR TITLE
Increase blur timeout

### DIFF
--- a/src/Suggestions.vue
+++ b/src/Suggestions.vue
@@ -93,7 +93,7 @@
       hideItems () {
         setTimeout(() => {
           this.showItems = false
-        }, 150)
+        }, 300)
       },
       showResults () {
         this.showItems = true


### PR DESCRIPTION
You should increase your blur timeout.
About 1 out of 20 @click events are missed due to the too short timeout.

(tested with Chrome on my old i7)

FX