### PR TITLE
Support Escape key

### DIFF
--- a/src/Suggestions.vue
+++ b/src/Suggestions.vue
@@ -116,6 +116,10 @@
             this.selectItem()
             e.preventDefault()
             break
+          case 27:
+            this.showItems = false
+            e.preventDefault()
+            break
           default:
             return true
         }


### PR DESCRIPTION
This PR adds an `onKeyDown` handler for closing the item list using the Escape key. 

I chose to have the items hide immediately, rather than use `hideItems`.