### PR TITLE
Change default inputClass

### DIFF
--- a/src/Suggestions.vue
+++ b/src/Suggestions.vue
@@ -51,7 +51,7 @@
       const defaultOptions = {
         debounce: 0,
         placeholder: '',
-        inputClass: 'input'
+        inputClass: 'v-suggestions-input'
       }
       const extendedOptions = Object.assign({}, defaultOptions, this.options)
       return {


### PR DESCRIPTION
`v-suggestions/dist/v-suggestions.css` contains the default style for `<input>`, but it is not applied as input has the class `input` by default instead of `v-suggestions-input`.